### PR TITLE
Issue #5: Fix Library name in License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,4 @@ Some other recommended HTTP libraries for PHP include:
 
 ## License
 
-Imap is licensed under the MIT (Expat) license. See included LICENSE.md.
+Request is licensed under the MIT (Expat) license. See included LICENSE.md.


### PR DESCRIPTION
Replace imap with Requests in License section of README.md

Fixes #5.